### PR TITLE
Features/improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The application can be configured through the `appsettings.json` file:
 - `VideoFolderName` *(string)*: Name of the folder where all the classified videos will be located.
 - `ImageExtensions` *(string array)*: Image extensions list the application will check for. If a compatible extension is not specified, the application will not read those files.
 - `VideoExtensions` *(string)*: Video extensions list the application will check for.  If a compatible extension is not specified, the application will not read those files.
+- `OverwriteFiles` *(boolena)*: Setting to allow overwrite files if the media type is already in the destination.
 - `RenameMediaFiles` *(boolean)*: Setting to allow rename media files with the created date or not. Ex: From `IMG_0001,heic` to `yyyy-MM-dd_HH-mm:ss_IMG_0001.heic`.
 - `ReplaceLongNames` *(boolean)*: Setting to allow replace the original long names with another one (composed by the setting `NewMediaName` and a 4-digit random number) when the original name is higher than the `MaxMediaNameLength` setting.
 - `NewMediaName` *(string)*: New media name to replace original names when the conditions are met. This name will be concatenated to a 4-digit random number. Ex: From `IMG_0001.heic` to `pbg_3107.heic`.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Order Media is a .NET 6 console application made to classify media files based o
 
 To have an ordered media catalog, this application will move each file to the corresponding folder based on the captured date.
 
-The default name of the files produced by cameras or phones are arbitrary and useless, the application will rename each file adding the captured date to the name. It will replace the original name if it is too long with a shorter one.
+The default name of the files produced by cameras or phones are arbitrary and useless, the application will rename each file adding the captured date to the name. It will replace the original name if it is too long with a shorter one if configured.
 
 ## How it works
 
@@ -34,9 +34,11 @@ Video:
 
 It also supports:
 
-- LivePhoto: if a `.heic` or `.jpg` file is a LivePhoto, the application will move and rename the video.
+- LivePhoto: if a `.heic` or `.jpg` file is a LivePhoto, the application will move and rename the video. Compatible video formats: `.mov` and `.mp4`.
 - Aae files: sometimes, Apple photos (like Portrait photos) export a `.aae` file with metadata related to the Portrait effect. The application will move and rename the file.
-- Xmp files: for raw media files, sometimes there is a sidecar file with `.xmp` extension. This file contains metadata about the photo. The application will move and rename the file.
+- Xmp files: For raw media files, sometimes there is a sidecar file with `.xmp` extension. This file contains metadata about the photo.
+    - The application will move and rename the file.
+    - The application will get the Created date from the file and not the raw file.
 - WhatsApp media:  if you share a photo or video from the iPhone to the Mac with AirDrop, the file will be called `PHOTO-yyyy-MM-dd-HH-mm-ss` or `VIDEO-yyyy-MM-dd-HH-mm-ss`. The application will extract the created date from this name and perform the classification.
 
 ## Configuration

--- a/src/OrderMedia.ConsoleApp/appsettings.json
+++ b/src/OrderMedia.ConsoleApp/appsettings.json
@@ -15,6 +15,7 @@
     ".mov",
     ".mp4"
   ],
+  "OverwriteFiles": false,
   "RenameMediaFiles": true,
   "ReplaceLongNames": true,
   "MaxMediaNameLength": 8,

--- a/src/OrderMedia/Extensions/ServiceCollectionExtension.cs
+++ b/src/OrderMedia/Extensions/ServiceCollectionExtension.cs
@@ -44,7 +44,8 @@ namespace OrderMedia.Extensions
                 .AddScoped<IProcessor, XmpProcessor>(s => s.GetService<XmpProcessor>())
                 .AddScoped<IProcessorFactory, ProcessorFactory>()
                 .AddScoped<IRandomizerService, RandomizerService>()
-                .AddScoped<IRenameService, RenameService>();
+                .AddScoped<IRenameService, RenameService>()
+                .AddScoped<IXmpExtractorService, XmpExtractorService>();
 
             return services;
         }

--- a/src/OrderMedia/Factories/ProcessorFactory.cs
+++ b/src/OrderMedia/Factories/ProcessorFactory.cs
@@ -29,25 +29,25 @@ namespace OrderMedia.Factories
 
         private IProcessor CreateImageProcessor()
         {
+            var livePhotoProcessor = (IProcessor) _serviceProvider.GetService(typeof(LivePhotoProcessor));
+            var aaeProcessor = (IProcessor) _serviceProvider.GetService(typeof(AaeProcessor));
+
             var mainProcessor = CreateDefaultProcessor();
 
-            var livePhotoProcessor = (IProcessor) _serviceProvider.GetService(typeof(LivePhotoProcessor));
-            livePhotoProcessor.SetProcessor(mainProcessor);
+            mainProcessor.AddProcessor(livePhotoProcessor);
+            mainProcessor.AddProcessor(aaeProcessor);
 
-            var aaeProcessor = (IProcessor) _serviceProvider.GetService(typeof(AaeProcessor));
-            aaeProcessor.SetProcessor(livePhotoProcessor);
-
-            return aaeProcessor;
+            return mainProcessor;
         }
 
         private IProcessor CreateRawProcessor()
         {
-            var mainProcessor = CreateDefaultProcessor();
-
             var xmpProcessor = (IProcessor)_serviceProvider.GetService(typeof(XmpProcessor));
-            xmpProcessor.SetProcessor(mainProcessor);
 
-            return xmpProcessor;
+            var mainProcessor = CreateDefaultProcessor();
+            mainProcessor.AddProcessor(xmpProcessor);
+
+            return mainProcessor;
         }
 
         private IProcessor CreateVideoProcessor()
@@ -60,9 +60,9 @@ namespace OrderMedia.Factories
             return CreateDefaultProcessor();
         }
 
-        private IProcessor CreateDefaultProcessor()
+        private BaseProcessor CreateDefaultProcessor()
         {
-            return (IProcessor) _serviceProvider.GetService(typeof(MainProcessor));
+            return (BaseProcessor) _serviceProvider.GetService(typeof(MainProcessor));
         }
     }
 }

--- a/src/OrderMedia/Interfaces/IConfigurationService.cs
+++ b/src/OrderMedia/Interfaces/IConfigurationService.cs
@@ -36,6 +36,12 @@
         string GetVideoFolderName();
 
         /// <summary>
+        /// Gets the setting to overwrite files or not.
+        /// </summary>
+        /// <returns>Bool with the overwrite files setting.</returns>
+        bool GetOverwriteFiles();
+
+        /// <summary>
         /// Gets the setting to rename media files or not.
         /// </summary>
         /// <returns>Bool with the rename meda file setting.</returns>

--- a/src/OrderMedia/Interfaces/IMetadataExtractorService.cs
+++ b/src/OrderMedia/Interfaces/IMetadataExtractorService.cs
@@ -13,6 +13,26 @@ namespace OrderMedia.Interfaces
 		/// <param name="mediaPath">Media path.</param>
 		/// <returns>IEnumerable with all the directories of the media.</returns>
 		public IEnumerable<MetadataExtractor.Directory> GetImageDirectories(string mediaPath);
+
+        /// <summary>
+        /// Gets Created Date for Raw images.
+        /// </summary>
+        /// <param name="mediaPath">Raw media path.</param>
+        /// <returns>Created date with yyyy:MM:dd HH:mm:ss format.</returns>
+        public string GetRawCreatedDate(string mediaPath);
+
+        /// <summary>
+        /// Gets Created Date for videos.
+        /// </summary>
+        /// <param name="mediaPath">Video media path.</param>
+        /// <returns>Created date with ddd MMM dd HH:mm:ss zzz yyyy format.</returns>
+        public string GetVideoCreatedDate(string mediaPath);
+
+        /// <summary>
+        /// Gets Created Date for regular images like .jpg, .jpge, .png, .heic and .gif.
+        /// </summary>
+        /// <param name="mediaPath">Image media path.</param>
+        /// <returns>Created date with yyyy:MM:dd HH:mm:ss format.</returns>
+        public string GetImageCreatedDate(string mediaPath);
     }
 }
-

--- a/src/OrderMedia/Interfaces/IProcessor.cs
+++ b/src/OrderMedia/Interfaces/IProcessor.cs
@@ -7,17 +7,11 @@ namespace OrderMedia.Interfaces
     /// </summary>
     public interface IProcessor
 	{
-		/// <summary>
-		/// Executes the processor method for the desired media.
-		/// </summary>
-		/// <param name="media">Media to be processed.</param>
-		public void Execute(Media media);
-
-		/// <summary>
-		/// Sets the processor.
-		/// </summary>
-		/// <param name="processor">Processor to be set.</param>
-		public void SetProcessor(IProcessor processor);
+        /// <summary>
+        /// Executes the processor method for the desired media.
+        /// </summary>
+        /// <param name="media">Media to be processed.</param>
+        public void Execute(Media media);
     }
 }
 

--- a/src/OrderMedia/Interfaces/IXmpExtractorService.cs
+++ b/src/OrderMedia/Interfaces/IXmpExtractorService.cs
@@ -1,0 +1,13 @@
+﻿namespace OrderMedia.Interfaces
+{
+	public interface IXmpExtractorService
+	{
+        /// <summary>
+        /// Gets the Created Date from an XMP file.
+        /// </summary>
+        /// <param name="xmpFilePath">XMP file path.</param>
+        /// <returns>Created Date with yyyy-MM-ddTHH:mm:ss format.</returns>
+        public string GetCreatedDate(string xmpFilePath);
+	}
+}
+

--- a/src/OrderMedia/OrderMedia.csproj
+++ b/src/OrderMedia/OrderMedia.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="XmpCore" Version="6.1.10.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Services\" />

--- a/src/OrderMedia/Services/ConfigurationService.cs
+++ b/src/OrderMedia/Services/ConfigurationService.cs
@@ -45,6 +45,12 @@ namespace OrderMedia.Services
             return section.Get<string>();
         }
 
+        public bool GetOverwriteFiles()
+        {
+            var section = _configuration.GetSection("OverwriteFiles");
+            return section.Get<bool>();
+        }
+
         public bool GetRenameMediaFiles()
         {
             var section = _configuration.GetSection("RenameMediaFiles");

--- a/src/OrderMedia/Services/CreatedDateExtractors/BaseCreatedDateExtractor.cs
+++ b/src/OrderMedia/Services/CreatedDateExtractors/BaseCreatedDateExtractor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Globalization;
+using OrderMedia.Interfaces;
+
+namespace OrderMedia.Services.CreatedDateExtractors
+{
+    public abstract class BaseCreatedDateExtractor : ICreatedDateExtractor
+    {
+        public abstract DateTime GetCreatedDateTime(string mediaPath);
+
+        protected static DateTime GetDateTimeFromStringWithFormat(string metadataString, string format, CultureInfo cultureInfo)
+        {
+            DateTime.TryParseExact(metadataString, format, cultureInfo, DateTimeStyles.None, out DateTime imageDate);
+
+            return imageDate;
+        }
+    }
+}
+

--- a/src/OrderMedia/Services/CreatedDateExtractors/ImageCreatedDateExtractor.cs
+++ b/src/OrderMedia/Services/CreatedDateExtractors/ImageCreatedDateExtractor.cs
@@ -1,15 +1,13 @@
 ﻿using System;
-using MetadataExtractor.Formats.Exif;
 using System.Globalization;
 using OrderMedia.Interfaces;
-using System.Linq;
 
 namespace OrderMedia.Services.CreatedDateExtractors
 {
     /// <summary>
     /// Date Extractor for media type Image.
     /// </summary>
-	public class ImageCreatedDateExtractor : ICreatedDateExtractor
+	public class ImageCreatedDateExtractor : BaseCreatedDateExtractor
     {
         private readonly IMetadataExtractorService _metadataExtractor;
 
@@ -18,28 +16,11 @@ namespace OrderMedia.Services.CreatedDateExtractors
             _metadataExtractor = metadataExtractor;
         }
 
-        public DateTime GetCreatedDateTime(string mediaPath)
+        public override DateTime GetCreatedDateTime(string mediaPath)
         {
-            var metadataDateTime = GetDateFromMetadata(mediaPath);
+            var metadataDateTime = _metadataExtractor.GetImageCreatedDate(mediaPath);
 
-            return GetCreatedDateTimeFromMetadataString(metadataDateTime);
-        }
-
-        private string GetDateFromMetadata(string mediaPath)
-        {
-            var directories = _metadataExtractor.GetImageDirectories(mediaPath);
-
-            var exifDirectory = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
-            var imageCreationDate = exifDirectory?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal);
-
-            return imageCreationDate;
-        }
-
-        private DateTime GetCreatedDateTimeFromMetadataString(string metadataString)
-        {
-            DateTime.TryParseExact(metadataString, "yyyy:MM:dd HH:mm:ss", new CultureInfo("es-ES", false), System.Globalization.DateTimeStyles.None, out DateTime imageDate);
-
-            return imageDate;
+            return GetDateTimeFromStringWithFormat(metadataDateTime, "yyyy:MM:dd HH:mm:ss", new CultureInfo("es-ES", false));
         }
     }
 }

--- a/src/OrderMedia/Services/CreatedDateExtractors/RawCreatedDateExtractor.cs
+++ b/src/OrderMedia/Services/CreatedDateExtractors/RawCreatedDateExtractor.cs
@@ -1,45 +1,53 @@
 ﻿using System;
-using MetadataExtractor.Formats.Exif;
 using System.Globalization;
 using OrderMedia.Interfaces;
-using System.Linq;
 
 namespace OrderMedia.Services.CreatedDateExtractors
 {
     /// <summary>
     /// Date Extractor for media type Raw.
     /// </summary>
-	public class RawCreatedDateExtractor : ICreatedDateExtractor
+	public class RawCreatedDateExtractor : BaseCreatedDateExtractor
     {
         private readonly IMetadataExtractorService _metadataExtractor;
+        private readonly IIOService _ioService;
+        private readonly IXmpExtractorService _xmpExtractorService;
 
-        public RawCreatedDateExtractor(IMetadataExtractorService metadataExtractor)
+        public RawCreatedDateExtractor(IMetadataExtractorService metadataExtractor, IIOService ioService, IXmpExtractorService xmpExtractorService)
         {
             _metadataExtractor = metadataExtractor;
+            _ioService = ioService;
+            _xmpExtractorService = xmpExtractorService;
         }
 
-        public DateTime GetCreatedDateTime(string mediaPath)
+        public override DateTime GetCreatedDateTime(string mediaPath)
         {
-            var metadataDateTime = GetDateFromMetadata(mediaPath);
+            var xmpFilePath = GetXmpFilePath(mediaPath);
 
-            return GetCreatedDateTimeFromMetadataString(metadataDateTime);
+            string dateTimeAsString;
+            string format;
+
+            if (_ioService.Exists(xmpFilePath))
+            {
+                dateTimeAsString = _xmpExtractorService.GetCreatedDate(xmpFilePath);
+                // we assume that the date will come with the format yyyy-MM-ddTHH:mm:ss
+                format = "yyyy-MM-ddTHH:mm:ss";
+            }
+            else
+            {
+                dateTimeAsString = _metadataExtractor.GetRawCreatedDate(mediaPath);
+                format = "yyyy:MM:dd HH:mm:ss";
+            }
+
+            return GetDateTimeFromStringWithFormat(dateTimeAsString, format, new CultureInfo("es-ES", false));
         }
 
-        private string GetDateFromMetadata(string mediaPath)
+        private string GetXmpFilePath(string mediaPath)
         {
-            var directories = _metadataExtractor.GetImageDirectories(mediaPath);
+            var folder = _ioService.GetDirectoryName(mediaPath);
+            var nameWithoutExtension = _ioService.GetFileNameWithoutExtension(mediaPath);
 
-            var exifDirectory = directories.OfType<ExifIfd0Directory>().FirstOrDefault();
-            var imageCreationDate = exifDirectory?.GetDescription(ExifIfd0Directory.TagDateTime);
-
-            return imageCreationDate;
-        }
-
-        private DateTime GetCreatedDateTimeFromMetadataString(string metadataString)
-        {
-            DateTime.TryParseExact(metadataString, "yyyy:MM:dd HH:mm:ss", new CultureInfo("es-ES", false), System.Globalization.DateTimeStyles.None, out DateTime imageDate);
-
-            return imageDate;
+            return _ioService.Combine(new string[] { folder, $"{nameWithoutExtension}.xmp" });
         }
     }
 }

--- a/src/OrderMedia/Services/CreatedDateExtractors/VideoCreatedDateExtractor.cs
+++ b/src/OrderMedia/Services/CreatedDateExtractors/VideoCreatedDateExtractor.cs
@@ -1,15 +1,13 @@
 ﻿using System;
-using MetadataExtractor.Formats.QuickTime;
 using System.Globalization;
 using OrderMedia.Interfaces;
-using System.Linq;
 
 namespace OrderMedia.Services.CreatedDateExtractors
 {
     /// <summary>
     /// Date Extractor for media type Video.
     /// </summary>
-	public class VideoCreatedDateExtractor : ICreatedDateExtractor
+	public class VideoCreatedDateExtractor : BaseCreatedDateExtractor
     {
         private readonly IMetadataExtractorService _metadataExtractor;
 
@@ -18,28 +16,11 @@ namespace OrderMedia.Services.CreatedDateExtractors
             _metadataExtractor = metadataExtractor;
         }
 
-        public DateTime GetCreatedDateTime(string mediaPath)
+        public override DateTime GetCreatedDateTime(string mediaPath)
         {
-            var metadataDateTime = GetDateFromMetadata(mediaPath);
+            var metadataDateTime = _metadataExtractor.GetVideoCreatedDate(mediaPath);
 
-            return SetCreatedDateTimeFromMetadataString(metadataDateTime);
-        }
-
-        private string GetDateFromMetadata(string mediaPath)
-        {
-            var directories = _metadataExtractor.GetImageDirectories(mediaPath);
-
-            var quickTimeDirectory = directories.OfType<QuickTimeMetadataHeaderDirectory>().FirstOrDefault();
-            var videoCreationDate = quickTimeDirectory?.GetDescription(QuickTimeMetadataHeaderDirectory.TagCreationDate);
-
-            return videoCreationDate;
-        }
-
-        private DateTime SetCreatedDateTimeFromMetadataString(string metadataString)
-        {
-            DateTime.TryParseExact(metadataString, "ddd MMM dd HH:mm:ss zzz yyyy", new CultureInfo("en-UK", false), System.Globalization.DateTimeStyles.None, out DateTime videoDate);
-
-            return videoDate;
+            return GetDateTimeFromStringWithFormat(metadataDateTime, "ddd MMM dd HH:mm:ss zzz yyyy", new CultureInfo("en-UK", false));
         }
     }
 }

--- a/src/OrderMedia/Services/CreatedDateExtractors/WhatsAppCreatedDateExtractor.cs
+++ b/src/OrderMedia/Services/CreatedDateExtractors/WhatsAppCreatedDateExtractor.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.IO;
 using System.Text.RegularExpressions;
 using OrderMedia.Interfaces;
 
@@ -9,11 +8,18 @@ namespace OrderMedia.Services.CreatedDateExtractors
     /// <summary>
     /// Date Extractor for media type WhatsApp.
     /// </summary>
-	public class WhatsAppCreatedDateExtractor : ICreatedDateExtractor
+	public class WhatsAppCreatedDateExtractor : BaseCreatedDateExtractor
     {
-        public DateTime GetCreatedDateTime(string mediaPath)
+        private readonly IIOService _ioService;
+
+        public WhatsAppCreatedDateExtractor(IIOService ioService)
         {
-            string name = GetName(mediaPath);
+            _ioService = ioService;
+        }
+
+        public override DateTime GetCreatedDateTime(string mediaPath)
+        {
+            string name = _ioService.GetFileNameWithoutExtension(mediaPath);
 
             string pattern = @"[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])-(0[0-9]|[1-2][0-9])-([0-5][0-9])-([0-5][0-9])";
 
@@ -21,19 +27,7 @@ namespace OrderMedia.Services.CreatedDateExtractors
 
             // We assume that the regex will succeed.
 
-            return GetCreatedDateTimeFromMetadataString(m.Value);
-        }
-
-        private string GetName(string mediaPath)
-        {
-            return Path.GetFileNameWithoutExtension(mediaPath);
-        }
-
-        private DateTime GetCreatedDateTimeFromMetadataString(string metadataString)
-        {
-            DateTime.TryParseExact(metadataString, "yyyy-MM-dd-HH-mm-ss", new CultureInfo("es-ES", false), System.Globalization.DateTimeStyles.None, out DateTime imageDate);
-
-            return imageDate;
+            return GetDateTimeFromStringWithFormat(m.Value, "yyyy-MM-dd-HH-mm-ss", new CultureInfo("es-ES", false));
         }
     }
 }

--- a/src/OrderMedia/Services/IOService.cs
+++ b/src/OrderMedia/Services/IOService.cs
@@ -10,6 +10,13 @@ namespace OrderMedia.Services
     /// </summary>
     public class IOService : IIOService
     {
+        private readonly IConfigurationService _configurationService;
+
+        public IOService(IConfigurationService configurationService)
+        {
+            _configurationService = configurationService;
+        }
+
         public IEnumerable<FileInfo> GetFilesByExtensions(string path, params string[] extensions)
         {
             var directory = new DirectoryInfo(path);
@@ -18,7 +25,7 @@ namespace OrderMedia.Services
 
         public void MoveMedia(string oldPath, string newPath)
         {
-            File.Move(oldPath, newPath);
+            File.Move(oldPath, newPath, _configurationService.GetOverwriteFiles());
         }
 
         public void CreateFolder(string path)

--- a/src/OrderMedia/Services/MetadataExtractorService.cs
+++ b/src/OrderMedia/Services/MetadataExtractorService.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.QuickTime;
 using OrderMedia.Interfaces;
 
 namespace OrderMedia.Services
@@ -9,6 +13,29 @@ namespace OrderMedia.Services
         public IEnumerable<Directory> GetImageDirectories(string mediaPath)
         {
             return ImageMetadataReader.ReadMetadata(mediaPath);
+        }
+
+        private string GetCreatedDate<T>(string mediaPath, int tagType)
+        {
+            var directories = GetImageDirectories(mediaPath);
+            var dateDirectory = directories.OfType<T>().FirstOrDefault() as Directory;
+
+            return dateDirectory?.GetDescription(tagType);
+        }
+
+        public string GetImageCreatedDate(string mediaPath)
+        {
+            return GetCreatedDate< ExifSubIfdDirectory>(mediaPath, ExifDirectoryBase.TagDateTimeOriginal);
+        }
+
+        public string GetRawCreatedDate(string mediaPath)
+        {
+            return GetCreatedDate<ExifIfd0Directory>(mediaPath, ExifIfd0Directory.TagDateTime);
+        }
+
+        public string GetVideoCreatedDate(string mediaPath)
+        {
+            return GetCreatedDate<QuickTimeMetadataHeaderDirectory>(mediaPath, QuickTimeMetadataHeaderDirectory.TagCreationDate);
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/AaeProcessor.cs
+++ b/src/OrderMedia/Services/Processors/AaeProcessor.cs
@@ -6,27 +6,19 @@ namespace OrderMedia.Services.Processors
     /// <summary>
     /// Processor for Aae files.
     /// </summary>
-	public class AaeProcessor : IProcessor
+	public class AaeProcessor : BaseProcessor
 	{
         private readonly IIOService _ioService;
         private readonly IRenameService _renameService;
-        private IProcessor Processor;
 
-        public AaeProcessor(IIOService ioService, IRenameService renameService)
+        public AaeProcessor(IIOService ioService, IRenameService renameService) : base()
         {
             _ioService = ioService;
             _renameService = renameService;
         }
 
-        public void SetProcessor(IProcessor processor)
+        public override void Execute(Media media)
         {
-            Processor = processor;
-        }
-
-        public void Execute(Media media)
-        {
-            Processor?.Execute(media);
-
             string aaeName = _renameService.GetAaeName(media.NameWithoutExtension);
             string aaeLocation = _ioService.Combine(new string[] { media.MediaFolder, aaeName });
 
@@ -37,6 +29,8 @@ namespace OrderMedia.Services.Processors
 
                 _ioService.MoveMedia(aaeLocation, newAaeLocation);
             }
+
+            ExecuteProcessors(media);
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/AaeProcessor.cs
+++ b/src/OrderMedia/Services/Processors/AaeProcessor.cs
@@ -1,4 +1,6 @@
-﻿using OrderMedia.Interfaces;
+﻿using System;
+using System.Collections.Generic;
+using OrderMedia.Interfaces;
 using OrderMedia.Models;
 
 namespace OrderMedia.Services.Processors
@@ -19,7 +21,25 @@ namespace OrderMedia.Services.Processors
 
         public override void Execute(Media media)
         {
-            string aaeName = _renameService.GetAaeName(media.NameWithoutExtension);
+            var possibleNames = new List<string>()
+            {
+                $"{media.NameWithoutExtension}.aae",
+                _renameService.GetAaeName(media.NameWithoutExtension),
+            };
+
+            foreach (var aaeName in possibleNames)
+            {
+                var result = FindAndMove(aaeName, media);
+
+                if (result)
+                    break;
+            }
+
+            ExecuteProcessors(media);
+        }
+
+        private bool FindAndMove(string aaeName, Media media)
+        {
             string aaeLocation = _ioService.Combine(new string[] { media.MediaFolder, aaeName });
 
             if (_ioService.Exists(aaeLocation))
@@ -28,10 +48,11 @@ namespace OrderMedia.Services.Processors
                 string newAaeLocation = _ioService.Combine(new string[] { media.NewMediaFolder, newAaeName });
 
                 _ioService.MoveMedia(aaeLocation, newAaeLocation);
+
+                return true;
             }
 
-            ExecuteProcessors(media);
+            return false;
         }
     }
 }
-

--- a/src/OrderMedia/Services/Processors/BaseProcessor.cs
+++ b/src/OrderMedia/Services/Processors/BaseProcessor.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using OrderMedia.Interfaces;
+using OrderMedia.Models;
+
+namespace OrderMedia.Services.Processors
+{
+	public abstract class BaseProcessor : IProcessor
+	{
+		protected List<IProcessor> processors = new List<IProcessor>();
+
+		public abstract void Execute(Media media);
+
+        public void AddProcessor(IProcessor processor)
+		{
+			processors.Add(processor);
+		}
+
+		protected void ExecuteProcessors(Media media)
+		{
+			foreach(var processor in processors)
+			{
+				processor.Execute(media);
+			}
+		}
+	}
+}
+

--- a/src/OrderMedia/Services/Processors/LivePhotoProcessor.cs
+++ b/src/OrderMedia/Services/Processors/LivePhotoProcessor.cs
@@ -6,25 +6,17 @@ namespace OrderMedia.Services.Processors
     /// <summary>
     /// Processor for LivePhoto files.
     /// </summary>
-	public class LivePhotoProcessor : IProcessor
+	public class LivePhotoProcessor : BaseProcessor
 	{
         private readonly IIOService _ioService;
-        private IProcessor Processor;
 
-        public LivePhotoProcessor(IIOService ioService)
+        public LivePhotoProcessor(IIOService ioService) : base()
         {
             _ioService = ioService;
         }
 
-        public void SetProcessor(IProcessor processor)
+        public override void Execute(Media media)
         {
-            Processor = processor;
-        }
-
-        public void Execute(Media media)
-        {
-            Processor?.Execute(media);
-
             string videoName = $"{media.NameWithoutExtension}.mov";
             string videoLocation = _ioService.Combine(new string[] { media.MediaFolder, videoName });
 
@@ -35,6 +27,8 @@ namespace OrderMedia.Services.Processors
 
                 _ioService.MoveMedia(videoLocation, newVideoLocation);
             }
+
+            ExecuteProcessors(media);
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/MainProcessor.cs
+++ b/src/OrderMedia/Services/Processors/MainProcessor.cs
@@ -24,9 +24,16 @@ namespace OrderMedia.Services.Processors
             }
 
             _ioService.CreateFolder(media.NewMediaFolder);
-            _ioService.MoveMedia(media.MediaPath, media.NewMediaPath);
 
-            ExecuteProcessors(media);
+            try
+            {
+                _ioService.MoveMedia(media.MediaPath, media.NewMediaPath);
+                ExecuteProcessors(media);
+            }
+            catch (Exception e)
+            {
+                return;
+            }
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/MainProcessor.cs
+++ b/src/OrderMedia/Services/Processors/MainProcessor.cs
@@ -1,4 +1,5 @@
-﻿using OrderMedia.Interfaces;
+﻿using System;
+using OrderMedia.Interfaces;
 using OrderMedia.Models;
 
 namespace OrderMedia.Services.Processors
@@ -6,27 +7,26 @@ namespace OrderMedia.Services.Processors
     /// <summary>
     /// Main processor for media files.
     /// </summary>
-	public class MainProcessor : IProcessor
+	public class MainProcessor : BaseProcessor
 	{
         private readonly IIOService _ioService;
-        private IProcessor Processor;
 
-        public MainProcessor(IIOService ioService)
+        public MainProcessor(IIOService ioService) : base()
         {
             _ioService = ioService;
         }
 
-        public void Execute(Media media)
+        public override void Execute(Media media)
         {
-            Processor?.Execute(media);
+            if (media.CreatedDateTime == default(DateTime))
+            {
+                return;
+            }
 
             _ioService.CreateFolder(media.NewMediaFolder);
             _ioService.MoveMedia(media.MediaPath, media.NewMediaPath);
-        }
 
-        public void SetProcessor(IProcessor processor)
-        {
-            Processor = processor;
+            ExecuteProcessors(media);
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/XmpProcessor.cs
+++ b/src/OrderMedia/Services/Processors/XmpProcessor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using OrderMedia.Interfaces;
+﻿using OrderMedia.Interfaces;
 using OrderMedia.Models;
 
 namespace OrderMedia.Services.Processors
@@ -7,27 +6,19 @@ namespace OrderMedia.Services.Processors
     /// <summary>
     /// Processor for Xmp files.
     /// </summary>
-    public class XmpProcessor : IProcessor
+    public class XmpProcessor : BaseProcessor
     {
         private readonly IIOService _ioService;
         private readonly IRenameService _renameService;
-        private IProcessor Processor;
 
-        public XmpProcessor(IIOService ioService, IRenameService renameService)
+        public XmpProcessor(IIOService ioService, IRenameService renameService) : base()
         {
             _ioService = ioService;
             _renameService = renameService;
         }
 
-        public void SetProcessor(IProcessor processor)
+        public override void Execute(Media media)
         {
-            Processor = processor;
-        }
-
-        public void Execute(Media media)
-        {
-            Processor?.Execute(media);
-
             string xmpName = $"{media.NameWithoutExtension}.xmp";
             string xmpLocation = _ioService.Combine(new string[] { media.MediaFolder, xmpName });
 
@@ -38,6 +29,8 @@ namespace OrderMedia.Services.Processors
 
                 _ioService.MoveMedia(xmpLocation, newXmpLocation);
             }
+
+            ExecuteProcessors(media);
         }
     }
 }

--- a/src/OrderMedia/Services/Processors/XmpProcessor.cs
+++ b/src/OrderMedia/Services/Processors/XmpProcessor.cs
@@ -9,12 +9,10 @@ namespace OrderMedia.Services.Processors
     public class XmpProcessor : BaseProcessor
     {
         private readonly IIOService _ioService;
-        private readonly IRenameService _renameService;
 
-        public XmpProcessor(IIOService ioService, IRenameService renameService) : base()
+        public XmpProcessor(IIOService ioService) : base()
         {
             _ioService = ioService;
-            _renameService = renameService;
         }
 
         public override void Execute(Media media)

--- a/src/OrderMedia/Services/RenameService.cs
+++ b/src/OrderMedia/Services/RenameService.cs
@@ -43,13 +43,19 @@ namespace OrderMedia.Services
 
         public string GetAaeName(string nameWithoutExtension)
         {
+            // Images with no proper name, return the same name.aae
+            if (nameWithoutExtension.Length < 5)
+            {
+                return $"{nameWithoutExtension}.aae";
+            }
+
             // Images with the (1) have the aae as IMG_xxxx (1)O.aae 
             if (nameWithoutExtension.Contains('('))
             {
                 return $"{nameWithoutExtension}O.aae";
             }
 
-            // Images with regular names have the aae as IMG_Oxxx.aae
+            // Images with regular names have the aae as IMG_Oxxxx.aae
             return $"{nameWithoutExtension.Insert(4, "O")}.aae";
         }
 

--- a/src/OrderMedia/Services/XmpExtractorService.cs
+++ b/src/OrderMedia/Services/XmpExtractorService.cs
@@ -1,0 +1,29 @@
+﻿using System.IO;
+using OrderMedia.Interfaces;
+using XmpCore;
+
+namespace OrderMedia.Services
+{
+	public class XmpExtractorService : IXmpExtractorService
+	{
+        public string GetCreatedDate(string xmpFilePath)
+        {
+            var xmpFile = GetXmpMeta(xmpFilePath);
+
+            return xmpFile.GetPropertyString("http://ns.adobe.com/exif/1.0/", "exif:DateTimeOriginal");
+        }
+
+        private IXmpMeta GetXmpMeta(string xmpFilePath)
+        {
+            IXmpMeta xmp;
+
+            using (var stream = File.OpenRead(xmpFilePath))
+            {
+                xmp = XmpMetaFactory.Parse(stream);
+            }
+
+            return xmp;
+        }
+    }
+}
+

--- a/src/OrderMediaTests/Factories/CreatedDateExtractorsFactoryTests.cs
+++ b/src/OrderMediaTests/Factories/CreatedDateExtractorsFactoryTests.cs
@@ -17,15 +17,18 @@ namespace OrderMediaTests.Factories
 
 			var metadataExtractorServiceMock = _autoMocker.GetMock<IMetadataExtractorService>();
 
+			var ioServiceMock = _autoMocker.GetMock<IIOService>();
+			var xmpExtractorServiceMock = _autoMocker.GetMock<IXmpExtractorService>();
+
 			_serviceProviderMock = _autoMocker.GetMock<IServiceProvider>();
 			_serviceProviderMock.Setup(x => x.GetService(typeof(ImageCreatedDateExtractor)))
 				.Returns(new ImageCreatedDateExtractor(metadataExtractorServiceMock.Object));
 			_serviceProviderMock.Setup(x => x.GetService(typeof(RawCreatedDateExtractor)))
-				.Returns(new RawCreatedDateExtractor(metadataExtractorServiceMock.Object));
+				.Returns(new RawCreatedDateExtractor(metadataExtractorServiceMock.Object, ioServiceMock.Object, xmpExtractorServiceMock.Object));
 			_serviceProviderMock.Setup(x => x.GetService(typeof(VideoCreatedDateExtractor)))
 				.Returns(new VideoCreatedDateExtractor(metadataExtractorServiceMock.Object));
 			_serviceProviderMock.Setup(x => x.GetService(typeof(WhatsAppCreatedDateExtractor)))
-				.Returns(new WhatsAppCreatedDateExtractor());
+				.Returns(new WhatsAppCreatedDateExtractor(ioServiceMock.Object));
 		}
 
 		[Test]

--- a/src/OrderMediaTests/Factories/ProcessorFactoryTests.cs
+++ b/src/OrderMediaTests/Factories/ProcessorFactoryTests.cs
@@ -38,8 +38,8 @@ namespace OrderMediaTests.Factories
         }
 
 		[Test]
-		[TestCase(MediaType.Image, typeof(AaeProcessor))]
-        [TestCase(MediaType.Raw, typeof(XmpProcessor))]
+		[TestCase(MediaType.Image, typeof(MainProcessor))]
+        [TestCase(MediaType.Raw, typeof(MainProcessor))]
         [TestCase(MediaType.Video, typeof(MainProcessor))]
         [TestCase(MediaType.WhatsAppImage, typeof(MainProcessor))]
         [TestCase(MediaType.WhatsAppVideo, typeof(MainProcessor))]

--- a/src/OrderMediaTests/Factories/ProcessorFactoryTests.cs
+++ b/src/OrderMediaTests/Factories/ProcessorFactoryTests.cs
@@ -24,7 +24,7 @@ namespace OrderMediaTests.Factories
 
 			var aaeProcessor = new AaeProcessor(ioServiceMock.Object, renameServiceMock.Object);
 
-            var xmpProcessor = new XmpProcessor(ioServiceMock.Object, renameServiceMock.Object);
+            var xmpProcessor = new XmpProcessor(ioServiceMock.Object);
 
             _serviceProviderMock = _autoMocker.GetMock<IServiceProvider>();
 			_serviceProviderMock.Setup(x => x.GetService(typeof(MainProcessor)))

--- a/src/OrderMediaTests/Services/ConfigurationServiceTests.cs
+++ b/src/OrderMediaTests/Services/ConfigurationServiceTests.cs
@@ -14,6 +14,8 @@ namespace OrderMediaTests.Services
         private string[] imageExtensions = new string[] { ".heic", ".jpg", ".jpeg", ".gif", ".png", ".arw", ".dng" };
         private string videoExtensionsName = "VideoExtensions";
         private string[] videoExtensions = new string[] { ".mov", ".mp4" };
+        private string OverwriteFilesName = "OverwriteFiles";
+        private bool OverwriteFiles = true;
         private string RenameMediaFilesName = "RenameMediaFiles";
         private bool RenameMediaFiles = true;
         private string ReplaceLongNamesName = "ReplaceLongNames";
@@ -41,6 +43,7 @@ namespace OrderMediaTests.Services
                 { $"{imageExtensionsName}:6", imageExtensions[6]},
                 { $"{videoExtensionsName}:0", videoExtensions[0]},
                 { $"{videoExtensionsName}:1", videoExtensions[1]},
+                { OverwriteFilesName, OverwriteFiles.ToString() },
                 { RenameMediaFilesName, RenameMediaFiles.ToString() },
                 { ReplaceLongNamesName, ReplaceLongNames.ToString() },
                 { MaxMediaNameLengthName, MaxMediaNameLength.ToString() },
@@ -130,6 +133,19 @@ namespace OrderMediaTests.Services
 
             // Assert
             result.Should().Be(RenameMediaFiles);
+        }
+
+        [Test]
+        public void GetOverwriteFiles_Success()
+        {
+            // Arrange
+            var sut = _autoMocker.CreateInstance<ConfigurationService>();
+
+            // Act
+            var result = sut.GetOverwriteFiles();
+
+            // Assert
+            result.Should().Be(OverwriteFiles);
         }
 
         [Test]

--- a/src/OrderMediaTests/Services/CreatedDateExtractors/ImageCreatedDateExtractorTests.cs
+++ b/src/OrderMediaTests/Services/CreatedDateExtractors/ImageCreatedDateExtractorTests.cs
@@ -24,15 +24,8 @@ namespace OrderMediaTests.Services.CreatedDateExtractors
 			var dateTime = new DateTime(2014, 07, 31, 22, 15, 15);
 			var dateTimeAsString = dateTime.ToString("yyyy:MM:dd HH:mm:ss");
 
-			var directoryList = new List<MetadataExtractor.Directory>();
-
-			var exifSubIfdDirectory = new ExifSubIfdDirectory();
-			exifSubIfdDirectory.Set(ExifDirectoryBase.TagDateTimeOriginal, dateTimeAsString);
-
-			directoryList.Add(exifSubIfdDirectory);
-
-			_metadataExtractor.Setup(x => x.GetImageDirectories(It.IsAny<string>()))
-				.Returns(directoryList);
+			_metadataExtractor.Setup(x => x.GetImageCreatedDate(It.IsAny<string>()))
+				.Returns(dateTimeAsString);
 
 			var sut = _autoMocker.CreateInstance<ImageCreatedDateExtractor>();
 

--- a/src/OrderMediaTests/Services/CreatedDateExtractors/RawCreatedDateExtractorTests.cs
+++ b/src/OrderMediaTests/Services/CreatedDateExtractors/RawCreatedDateExtractorTests.cs
@@ -7,37 +7,77 @@ namespace OrderMediaTests.Services.CreatedDateExtractors
     public class RawCreatedDateExtractorTests
 	{
         private AutoMocker _autoMocker;
-        private Mock<IMetadataExtractorService> _metadataExtractor;
+        private Mock<IMetadataExtractorService> _metadataExtractorMock;
+        private Mock<IIOService> _ioServiceMock;
+        private Mock<IXmpExtractorService> _xmpExtractorServiceMock;
 
         [SetUp]
         public void SetUp()
         {
             _autoMocker = new AutoMocker();
 
-            _metadataExtractor = _autoMocker.GetMock<IMetadataExtractorService>();
+            _metadataExtractorMock = _autoMocker.GetMock<IMetadataExtractorService>();
+
+            _ioServiceMock = _autoMocker.GetMock<IIOService>();
+
+            _xmpExtractorServiceMock = _autoMocker.GetMock<IXmpExtractorService>();
         }
 
         [Test]
-        public void GetCreatedDateTime_Returns_DateTime()
+        public void GetCreatedDateTime_FromRawFile_Returns_DateTime()
         {
             // Arrange
             var dateTime = new DateTime(2014, 07, 31, 22, 15, 15);
             var dateTimeAsString = dateTime.ToString("yyyy:MM:dd HH:mm:ss");
 
-            var directoryList = new List<MetadataExtractor.Directory>();
+            _ioServiceMock.Setup(x => x.Exists(It.IsAny<string>()))
+                .Returns(false);
 
-            var exifIfd0Directory = new ExifIfd0Directory();
-            exifIfd0Directory.Set(ExifIfd0Directory.TagDateTime, dateTimeAsString);
-
-            directoryList.Add(exifIfd0Directory);
-
-            _metadataExtractor.Setup(x => x.GetImageDirectories(It.IsAny<string>()))
-                .Returns(directoryList);
+            _metadataExtractorMock.Setup(x => x.GetRawCreatedDate(It.IsAny<string>()))
+                .Returns(dateTimeAsString);
 
             var sut = _autoMocker.CreateInstance<RawCreatedDateExtractor>();
 
             // Act
             var result = sut.GetCreatedDateTime("image.raw");
+
+            // Assert
+            result.Should().Be(dateTime);
+        }
+
+        [Test]
+        public void GetCreatedDateTime_FromXmpFile_Returns_DateTime()
+        {
+            // Arrange
+            var mediaFileName = "image";
+            var mediaFileExtension = ".raw";
+            var mediaFileFolder = "test/";
+            var mediaFilePath = $"{mediaFileFolder}{mediaFileName}{mediaFileExtension}";
+            var xmpFileName = "image.xmp";
+            var xmpFilePath = $"{mediaFileFolder}{xmpFileName}";
+
+            var dateTime = new DateTime(2014, 07, 31, 22, 15, 15);
+            var dateTimeAsString = dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
+
+            _ioServiceMock.Setup(x => x.GetDirectoryName(mediaFilePath))
+                .Returns(mediaFileFolder);
+
+            _ioServiceMock.Setup(x => x.GetFileNameWithoutExtension(mediaFilePath))
+                .Returns(mediaFileName);
+
+            _ioServiceMock.Setup(x => x.Combine(new string[] { mediaFileFolder, xmpFileName }))
+                .Returns(xmpFilePath);
+
+            _ioServiceMock.Setup(x => x.Exists(xmpFilePath))
+                .Returns(true);
+
+            _xmpExtractorServiceMock.Setup(x => x.GetCreatedDate(xmpFilePath))
+                .Returns(dateTimeAsString);
+
+            var sut = _autoMocker.CreateInstance<RawCreatedDateExtractor>();
+
+            // Act
+            var result = sut.GetCreatedDateTime(mediaFilePath);
 
             // Assert
             result.Should().Be(dateTime);

--- a/src/OrderMediaTests/Services/CreatedDateExtractors/VideoCreatedDateExtractorTests.cs
+++ b/src/OrderMediaTests/Services/CreatedDateExtractors/VideoCreatedDateExtractorTests.cs
@@ -25,15 +25,8 @@ namespace OrderMediaTests.Services.CreatedDateExtractors
             var dateTime = new DateTime(2014, 07, 31, 22, 15, 15);
             var dateTimeAsString = dateTime.ToString("ddd MMM dd HH:mm:ss zzz yyyy", new CultureInfo("en-UK", false));
 
-            var directoryList = new List<MetadataExtractor.Directory>();
-
-            var quickTimeMetadataHeaderDirectory = new QuickTimeMetadataHeaderDirectory();
-            quickTimeMetadataHeaderDirectory.Set(QuickTimeMetadataHeaderDirectory.TagCreationDate, dateTimeAsString);
-
-            directoryList.Add(quickTimeMetadataHeaderDirectory);
-
-            _metadataExtractor.Setup(x => x.GetImageDirectories(It.IsAny<string>()))
-                .Returns(directoryList);
+            _metadataExtractor.Setup(x => x.GetVideoCreatedDate(It.IsAny<string>()))
+                .Returns(dateTimeAsString);
 
             var sut = _autoMocker.CreateInstance<VideoCreatedDateExtractor>();
 

--- a/src/OrderMediaTests/Services/CreatedDateExtractors/WhatsAppCreatedDateExtractorTests.cs
+++ b/src/OrderMediaTests/Services/CreatedDateExtractors/WhatsAppCreatedDateExtractorTests.cs
@@ -1,16 +1,19 @@
-﻿using OrderMedia.Services.CreatedDateExtractors;
+﻿using OrderMedia.Interfaces;
+using OrderMedia.Services.CreatedDateExtractors;
 
 namespace OrderMediaTests.Services.CreatedDateExtractors
 {
     public class WhatsAppCreatedDateExtractorTests
 	{
         private AutoMocker _autoMocker;
+        private Mock<IIOService> _ioServiceMock;
 
         [SetUp]
         public void SetUp()
         {
             _autoMocker = new AutoMocker();
 
+            _ioServiceMock = _autoMocker.GetMock<IIOService>();
         }
 
         [Test]
@@ -20,7 +23,12 @@ namespace OrderMediaTests.Services.CreatedDateExtractors
             var dateTime = new DateTime(2014, 07, 31, 22, 15, 15);
             var dateTimeAsString = dateTime.ToString("yyyy-MM-dd-HH-mm-ss");
 
-            var path = $"test/PHOTO-{dateTimeAsString}.jpg";
+            var mediaName = $"PHOTO-{dateTimeAsString}.jpg";
+
+            var path = $"test/{mediaName}";
+
+            _ioServiceMock.Setup(x => x.GetFileNameWithoutExtension(It.IsAny<string>()))
+                .Returns(mediaName);
 
             var sut = _autoMocker.CreateInstance<WhatsAppCreatedDateExtractor>();
 

--- a/src/OrderMediaTests/Services/Processors/LivePhotoProcessorTests.cs
+++ b/src/OrderMediaTests/Services/Processors/LivePhotoProcessorTests.cs
@@ -40,6 +40,9 @@ namespace OrderMediaTests.Services.Processors
             _ioServiceMock.Setup(x => x.Combine(new string[] { media.MediaFolder, videoName }))
                 .Returns(videoLocation);
 
+            _ioServiceMock.Setup(x => x.GetExtension(It.IsAny<string>()))
+                .Returns(".mov");
+
             _ioServiceMock.Setup(x => x.Exists(videoLocation))
                 .Returns(true);
 

--- a/src/OrderMediaTests/Services/Processors/MainProcessorTests.cs
+++ b/src/OrderMediaTests/Services/Processors/MainProcessorTests.cs
@@ -26,6 +26,7 @@ namespace OrderMediaTests.Services.Processors
                 NewMediaFolder = "/2014-07-31/",
                 MediaPath = "test/photos/IMG_0001.jpg",
                 NewMediaPath = "test/photos/img/2014-07-31/2014-07-31_22-15-15_IMG_0001.jpg",
+                CreatedDateTime = new DateTime(2014, 07, 31, 22, 15, 15),
             };
 
             var sut = _autoMocker.CreateInstance<MainProcessor>();
@@ -36,6 +37,27 @@ namespace OrderMediaTests.Services.Processors
             // Assert
             _ioServiceMock.Verify(x => x.CreateFolder(media.NewMediaFolder), Times.Once);
             _ioServiceMock.Verify(x => x.MoveMedia(media.MediaPath, media.NewMediaPath), Times.Once);
+        }
+
+        [Test]
+        public void Execute_Runs_WithNoClassificableMedia()
+        {
+            // Arrange
+            var media = new Media()
+            {
+                NewMediaFolder = "/2014-07-31/",
+                MediaPath = "test/photos/IMG_0001.jpg",
+                NewMediaPath = "test/photos/img/2014-07-31/2014-07-31_22-15-15_IMG_0001.jpg",
+            };
+
+            var sut = _autoMocker.CreateInstance<MainProcessor>();
+
+            // Act
+            sut.Execute(media);
+
+            // Assert
+            _ioServiceMock.Verify(x => x.CreateFolder(media.NewMediaFolder), Times.Never);
+            _ioServiceMock.Verify(x => x.MoveMedia(media.MediaPath, media.NewMediaPath), Times.Never);
         }
     }
 }

--- a/src/OrderMediaTests/Services/RenameServiceTests.cs
+++ b/src/OrderMediaTests/Services/RenameServiceTests.cs
@@ -61,6 +61,7 @@ namespace OrderMediaTests.Services
         [Test]
 		[TestCase("IMG_0001", "IMG_O0001.aae")]
         [TestCase("IMG_0001 (1)", "IMG_0001 (1)O.aae")]
+        [TestCase("Test", "Test.aae")]
         public void GetAaeName_Returns_AaeName_Successfully(string nameWithoutExtension, string aaeName)
 		{
 			// Arrange


### PR DESCRIPTION
- If a Media has default CreatedDateTime will not be processed.
- Added the ability to check multiple aae names.
-  Fixed error while getting the name of the aae file for media files with small name.
- Add the ability to check multiple livephotos video extensions.
- Added ability to extract the created date from an XMP file.
- Allow to overwrite files.